### PR TITLE
Fix: error in connected-react-router crashes the app

### DIFF
--- a/client/src/redux/store.js
+++ b/client/src/redux/store.js
@@ -25,7 +25,7 @@ export default function configureStore(history) {
       : compose;
   /* eslint-enable */
 
-  const rootReducer = createReducer();
+  const rootReducer = createReducer({ router: connectRouter(history) });
   const persistConfig = {
     key: 'root',
     whitelist: ['login'],

--- a/client/src/redux/store.js
+++ b/client/src/redux/store.js
@@ -34,7 +34,7 @@ export default function configureStore(history) {
   const persistedReducer = persistReducer(persistConfig, rootReducer);
 
   const store = createStore(
-    connectRouter(history)(persistedReducer),
+    persistedReducer,
     initialState,
     composeEnhancers(...enhancers),
   );


### PR DESCRIPTION
Linked to https://github.com/supasate/connected-react-router/issues/174.

`connected-react-router` needs to be stored under the `router` redux key. App would crash otherwise.

It appears that the Renovate bot introduced this regression while bumping `connected-react-router` from v4 to v5 (https://github.com/theodo/francis/pull/53). This major version change introduced (rightfully) a breaking change : https://github.com/supasate/connected-react-router/releases/tag/v5.0.0.

I would advise strongly against merging major version changes without doing a full reinstall of the project to test for regressions. This one cost me ~1h :(
