### PR TITLE
Add php cs fixer with Mano Mano rules

### DIFF
--- a/api/.php_cs.dist
+++ b/api/.php_cs.dist
@@ -1,14 +1,56 @@
 <?php
 
 $finder = PhpCsFixer\Finder::create()
-    ->exclude('var')
-    ->in(__DIR__)
-;
+   ->in(
+       [
+           __DIR__.'/src',
+           __DIR__.'/tests'
+       ]
+   );
 
 return PhpCsFixer\Config::create()
+    ->setFinder($finder)
+    ->setRiskyAllowed(true)
+    ->setUsingCache(false) // cache is always an issue when you switch branch because the cached file is ignored by git
     ->setRules([
         '@Symfony' => true,
+
+        // risky rules
+        '@Symfony:risky' => true,
+        'strict_comparison' => true,
+        'strict_param' => true,
+
+        // non risky rules
+        'array_indentation' => true,
         'array_syntax' => ['syntax' => 'short'],
+        'combine_consecutive_unsets' => true,
+        'declare_strict_types' => true,
+        'dir_constant' => true,
+        'fully_qualified_strict_types' => true,
+        'linebreak_after_opening_tag' => true,
+        'mb_str_functions' => true,
+        'modernize_types_casting' => true,
+        'no_alternative_syntax' => true,
+        'no_multiline_whitespace_before_semicolons' => true,
+        'no_null_property_initialization' => true,
+        'no_php4_constructor' => true,
+        'no_short_echo_tag' => true,
+        'no_superfluous_elseif' => true,
+        'no_unreachable_default_argument_value' => true,
+        'no_useless_else' => true,
+        'no_useless_return' => true,
+        'ordered_class_elements' => true,
+        'ordered_imports' => true,
+        'phpdoc_order' => true,
+        'phpdoc_to_comment' => false,
+        'phpdoc_types_order' => [
+            'null_adjustment' => 'always_last',
+            'sort_algorithm' => 'none'
+        ],
+        'php_unit_set_up_tear_down_visibility' => true,
+        'pow_to_exponentiation' => true,
+        'protected_to_private' => true,
+        'semicolon_after_instruction' => true,
+        'ternary_to_null_coalescing' => true,
     ])
-    ->setFinder($finder)
 ;

--- a/api/composer.json
+++ b/api/composer.json
@@ -18,6 +18,7 @@
     "require-dev": {
         "api-platform/schema-generator": "2.1.0",
         "doctrine/doctrine-fixtures-bundle": "^3.0",
+        "friendsofphp/php-cs-fixer": "^2.13",
         "fzaninotto/faker": "^1.8",
         "symfony/console": "4.1.7",
         "symfony/dotenv": "4.1.7",

--- a/api/composer.json
+++ b/api/composer.json
@@ -33,6 +33,7 @@
         "symfony/test-pack": "1.0.4"
     },
     "config": {
+        "bin-dir": "bin",
         "preferred-install": {
             "*": "dist"
         },

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Entity;
 
 use ApiPlatform\Core\Annotation\ApiResource;

--- a/api/src/Kernel.php
+++ b/api/src/Kernel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App;
 
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;

--- a/api/src/Repository/UserRepository.php
+++ b/api/src/Repository/UserRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Repository;
 
 use App\Entity\User;

--- a/api/tests/Controller/UserTest.php
+++ b/api/tests/Controller/UserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;


### PR DESCRIPTION
Hello la Francis team 🥮,

J'ai rajouté php cs fixer dans le projet avec la config de Mano Mano. Puis je l'ai lancé sur le projet, mais bon il y a pas beaucoup de fichier donc on voit pas bien l'impact. Voici les docs de toutes les régles implémentés : https://cs.sensiolabs.org/.

Next step : 
- Trouver un moyen simple de lancer le linter en local, sur suez et overlay on utilise un makefile pour cela @benja-M-1 @Remy-Luciani  vous avez des idées ?
- Ajouter le check du linter dans la CI

⚠️⚠️Le composer.lock n'est pas modifié car la dépendance  "php-cs-fixer" est deja dedans !!! EN tant qu' archi ça me rassure vraiment pas sur la qualité du générateur. Cette semaine sur suez on a un bug car il y avait une dépendance qui était dans le lock et pas le package.json, ca nous a fait perdre 1 heure :/

@Bernardstanislas Je penses que ca vaut le coup que tu fasses un check sur le fait que 100% des dépendances du projets sont dans le composer.lock ET le composer.json. Tu en penses quoi ? 